### PR TITLE
Fix docker compose containers not being grouped into folders

### DIFF
--- a/src/folder.view2/usr/local/emhttp/plugins/folder.view2/scripts/docker.js
+++ b/src/folder.view2/usr/local/emhttp/plugins/folder.view2/scripts/docker.js
@@ -404,7 +404,7 @@ const createFolder = (folder, id, positionInMainOrder, liveOrderArray, container
         if (!$containerTR.length || !$containerTR.hasClass('sortable')) {
             if(FOLDER_VIEW_DEBUG_MODE) console.log(`[FV2_DEBUG] createFolder (id: ${id}), container ${container_name_in_folder}: TR not found by ID or not sortable. Fallback search...`);
             $containerTR = $("#docker_list > tr.sortable").filter(function() {
-                return $(this).find("td.ct-name .appname a").text().trim() === container_name_in_folder;
+                return $(this).find("td.ct-name .appname").text().trim() === container_name_in_folder;
             }).first();
         }
 


### PR DESCRIPTION
This fixes docker compose containers not being grouped correctly into folders.
The issue was mentioned multiple times in the support thread.

Cause:
Containers created with docker compose do not have a link in their title on the list as the standard ones do.
Searching by their name queried `td.ct-name .appname a` which didn't give any results.

Docker compose container HTML:
```html
<span class="inner">
    <span class="appname ">example-container-name</span><br>
    <i id="load-ffffffffffff" class="fa fa-play started green-text"></i>
    <span class="state">started<br>Compose Stack: example-stack-name</span>
</span>
```

Standard Unraid docker container HTML:
```html
<span class="inner">
    <span class="appname ">
        <a class="exec" onclick="editContainer('example-container-name','/boot/config/plugins/dockerMan/templates-user/my-example-container-name.xml')">example-container-name</a>
    </span><br>
    <i id="load-ffffffffffff" class="fa fa-play started green-text"></i>
    <span class="state">started</span>
</span>
```

Changing the query to `td.ct-name .appname` fixes docker compose issues and does not interfere with standard containers.