### PR TITLE
Fix CPU/MEM graph empty

### DIFF
--- a/src/folder.view2/usr/local/emhttp/plugins/folder.view2/scripts/docker.js
+++ b/src/folder.view2/usr/local/emhttp/plugins/folder.view2/scripts/docker.js
@@ -1208,10 +1208,12 @@ $.get('/plugins/folder.view2/server/cpu.php').promise().then((data) => {
         let load = {};
         e.split('\n').forEach((e) => {
             const exp = e.split(';');
-            load[exp[0]] = {
-                cpu: exp[1],
-                mem: exp[2].split(' / ')
-            };
+            if (exp.length >= 3) {
+                load[exp[0]] = {
+                    cpu: exp[1],
+                    mem: exp[2].split(' / ')
+                };
+            }
         });
         for (const [id, value] of Object.entries(globalFolders)) {
             let loadCpu = 0;


### PR DESCRIPTION
Fixes empty CPU/RAM graphs caused by trailing newline in SSE data. 
Empty lines cause \`exp[2]\` to be undefined. So we skip lines with fewer than 3 fields.